### PR TITLE
Add Multisite Network Support for Media Library Alt Text Updater

### DIFF
--- a/alt-text.php
+++ b/alt-text.php
@@ -4,7 +4,7 @@
  * Plugin Name: Media Library Alt Text Updater
  * Plugin URI: https://prolificdigital.com
  * Description: A standalone plugin that updates image block alt text in posts and pages with the corresponding alt text from the media library. This plugin targets images that are missing alt text and ensures all images have descriptive alt text for better accessibility and SEO.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Prolific Digital
  * Author URI: https://prolificdigital.com
  * License: GPL-2.0+
@@ -27,17 +27,19 @@ add_filter('render_block', 'media_library_alt_text_updater', 10, 2);
  */
 function media_library_alt_text_updater($content, $block) {
   // Check if the block is an image block
-  if ('core/image' !== $block['blockName'])
+  if ('core/image' !== $block['blockName']) {
     return $content;
+  }
 
   // Retrieve the alt text from the media library if the image ID is set
   if (isset($block['attrs']['id'])) {
-    $alt = get_post_meta($block['attrs']['id'], '_wp_attachment_image_alt', true);
+    $alt = get_image_alt_text($block['attrs']['id']);
   }
 
   // If the alt text is empty, return the original content
-  if (empty($alt))
+  if (empty($alt)) {
     return $content;
+  }
 
   // If the alt attribute is empty in the content, replace it with the alt text from the media library
   if (false !== strpos($content, 'alt=""')) {
@@ -50,4 +52,24 @@ function media_library_alt_text_updater($content, $block) {
 
   // Return the modified content
   return $content;
+}
+
+/**
+ * Retrieve the alt text for an image from the media library.
+ *
+ * @param int $image_id The image ID.
+ * @return string The alt text.
+ */
+function get_image_alt_text($image_id) {
+  // Get the alt text from the current site
+  $alt = get_post_meta($image_id, '_wp_attachment_image_alt', true);
+
+  // If the alt text is empty, switch to the main site (site ID 1) and check there
+  if (empty($alt) && is_multisite() && get_current_blog_id() !== 1) {
+    switch_to_blog(1);
+    $alt = get_post_meta($image_id, '_wp_attachment_image_alt', true);
+    restore_current_blog();
+  }
+
+  return $alt;
 }

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ This plugin will display the alt text for images on the frontend, but you will n
 
 - **Automatic Alt Text Update:** Automatically updates image block alt text in posts and pages.
 - **Media Library Integration:** Uses alt text from the media library.
+- **Multisite Support:** Supports multisite networks, including those using a single media library for site ID 1.
 - **Missing Alt Text Targeting:** Targets images that are missing alt text.
 - **Accessibility and SEO Improvement:** Improves website accessibility and SEO.
 - **Editor Override:** Allows for manual override of alt text on an image-by-image basis within the WordPress editor.
@@ -40,7 +41,7 @@ Once the plugin is activated, it will automatically update the alt text for imag
 
 ### Does this plugin update existing image blocks?
 
-Yes, the plugin updates existing image blocks in your posts, page, or custom psot type to ensure they have alt text from the media library.
+Yes, the plugin updates existing image blocks in your posts, pages, or custom post types to ensure they have alt text from the media library.
 
 ### What happens if an image in the media library does not have alt text?
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
-=== AnimateWP ===
+=== Media Library Alt Text Updater ===
 Contributors: millertchris
 Donate link: https://prolificdigital.com
 Tags: alt text, media, images, accessibility, seo
 Requires at least: 6.0
 Tested up to: 6.6.1
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 A plugin that updates image block alt text using the media library's alt text, improving accessibility and SEO.


### PR DESCRIPTION
# Add Multisite Network Support for Media Library Alt Text Updater

## Description
This pull request enhances the Media Library Alt Text Updater plugin by adding support for multisite networks, including those using a single media library for site ID 1. This update ensures that alt text for image blocks can be retrieved from the main site’s media library when not found in the current subsite, improving accessibility and SEO across the entire network.

## Changes
- Updated the plugin to check for alt text in the main site (site ID 1) if not found in the current subsite.
- Enhanced the README file to include details about multisite network support and usage.
- Improved code comments and structure for better readability and maintenance.